### PR TITLE
Add Extra Ktor Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ and on deeper level. _Note: The book is not talking directly about Ktor, however
 - [Ktor OpenAPI Spec Generator](https://github.com/bkbnio/kompendium)
 - [Tegral OpenAPI](https://tegral.zoroark.guru/docs/modules/core/openapi/)
 - [Kryptokrona Kotlin SDK](https://github.com/kryptokrona/kryptokrona-kotlin-sdk) Kryptokrona SDK in Kotlin for building decentralized private communication and payment systems. Uses Ktor client library to fetch data from RPC.
+- [Extra Ktor Plugins](https://github.com/Flaxoos/extra-ktor-plugins) A library of extra plugins for multiplatform ktor server / client, including a plugin for Kafka, a flexible rate limiter plugin and a circuit breaker for ktor clients
 
 ## Contributing
 


### PR DESCRIPTION
Extending Ktor for the kotlin community:

While Kotlin is seeing widespread adoption, its web framework, Ktor, is sometimes overlooked, largely because Spring Boot still offers an exhaustive range of starters. To bridge this gap, kotlin fans like myself, could contribute to enhancing Ktor's functionality, which will increase adoption and further stimulate contribution by others. And so, I've developed a library of extra Ktor plugins.